### PR TITLE
Only run futurize on python files; removed a couple of fixers

### DIFF
--- a/wmcore_base/ContainerScripts/pyfutureTest.sh
+++ b/wmcore_base/ContainerScripts/pyfutureTest.sh
@@ -5,6 +5,7 @@ if [ -z "$ghprbPullId" -o -z "$ghprbTargetBranch" ]; then
   exit 1
 fi
 
+echo "$(TZ=GMT date): running pyfutureTest.sh script"
 source ./env_unittest.sh
 
 pushd wmcore_unittest/WMCore
@@ -15,19 +16,23 @@ git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
 export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
 git checkout -f ${COMMIT}
 
-futurize -1 src/ test/ > test.patch
-
-# Get changed files and analyze for idioms
-git diff --name-only  ${ghprbTargetBranch}..${COMMIT} > changedFiles.txt
+echo "$(TZ=GMT date): figuring out what are the files that changed"
+# Find all the changed files and filter python-only
+git diff --name-only  ${ghprbTargetBranch}..${COMMIT} > allChangedFiles.txt
+${HOME}/ContainerScripts/IdentifyPythonFiles.py allChangedFiles.txt > changedFiles.txt
 git diff-tree --name-status  -r ${ghprbTargetBranch}..${COMMIT} | egrep "^A" | cut -f 2 > addedFiles.txt
 
+echo "$(TZ=GMT date): running futurize 1st stage and some fixers"
 while read name; do
-  futurize -f execfile -f filter -f raw_input >> test.patch || true
+  futurize -1 $name >> test.patch
+  futurize -f execfile -f filter -f raw_input $name >> test.patch || true
   futurize -f idioms $name  >> idioms.patch || true
 done <changedFiles.txt
 
+# Get added files and analyze future imports
+echo "$(TZ=GMT date): running AnalyzePyFuture.py script"
 ${HOME}/ContainerScripts/AnalyzePyFuture.py > added.message
 
 cp test.patch idioms.patch added.message ${HOME}/artifacts/
-
+echo "$(TZ=GMT date): done with all tests and copying files over to artifacts!"
 popd


### PR DESCRIPTION
For my own information, these changes will affect the jenkins project called `DMWM-WMCore-PR-27`.

Changes are:
* added some timestamps
* filter any non-python files out (e.g. fixes the error "Can't parse test/python/WMCore_t/test_condor.log")
* commented out a few fixers that were broken already (e.g. fixes the error "At least one file or directory argument required.")
