### PR TITLE
Only check python3 compatibility on python files

### DIFF
--- a/wmcore_base/ContainerScripts/pyfutureTest.sh
+++ b/wmcore_base/ContainerScripts/pyfutureTest.sh
@@ -20,7 +20,9 @@ echo "$(TZ=GMT date): figuring out what are the files that changed"
 # Find all the changed files and filter python-only
 git diff --name-only  ${ghprbTargetBranch}..${COMMIT} > allChangedFiles.txt
 ${HOME}/ContainerScripts/IdentifyPythonFiles.py allChangedFiles.txt > changedFiles.txt
-git diff-tree --name-status  -r ${ghprbTargetBranch}..${COMMIT} | egrep "^A" | cut -f 2 > addedFiles.txt
+git diff-tree --name-status  -r ${ghprbTargetBranch}..${COMMIT} | egrep "^A" | cut -f 2 > allAddedFiles.txt
+${HOME}/ContainerScripts/IdentifyPythonFiles.py allAddedFiles.txt > addedFiles.txt
+rm -f allChangedFiles.txt allAddedFiles.txt
 
 echo "$(TZ=GMT date): running futurize 1st stage and some fixers"
 while read name; do


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/8904
That text file is later on used by the `DMWM-WMCore-PR-27` jenkins task, with the AnalyzePyFuture.py script.