### PR TITLE
Trigger new release of wmcore_tests image

### DIFF
--- a/wmcore_tests/Dockerfile
+++ b/wmcore_tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM gitlab-registry.cern.ch/cmsdocks/dmwm:wmcore_base
 
-RUN echo "2017-03-01" # Change to tickle new release
+RUN echo "2019-03-15" # Change to tickle new release
 RUN sh ContainerScripts/installWMCore.sh
 
 RUN sh ContainerScripts/updateGit.sh


### PR DESCRIPTION
I'm not sure it will work, but let me try the comment suggestion.
Checking CMSDocks jobs, I see the last time new docker images were built was when we made/merged changes to this repo.

It should build a 1.1.20.patch5 wmcore release.