### PR TITLE
Install pip and pylint on the wmcore_base docker image

### DIFF
--- a/wmcore_base/Dockerfile
+++ b/wmcore_base/Dockerfile
@@ -4,7 +4,9 @@ FROM gitlab-registry.cern.ch/cmsdocks/dmwm:cms_grid
 
 RUN echo "Updating the base system - 2017-06-16"
 
-RUN yum -y install cern-get-sso-cookie && yum clean all
+RUN yum -y install cern-get-sso-cookie python-pip && yum clean all
+RUN pip --no-cache-dir install --upgrade pip setuptools
+RUN pip --no-cache-dir install pylint==1.9.4
 
 # Add a new user (CMS stuff refuses to install as root)
 


### PR DESCRIPTION
Upgrade pylint used on some of the jenkins tests, such that it doesn't report an error when importing python3 libraries. It will also update pip, these are the versions from my test:
```
[dmwm@388792c1986c ~]$ pip --version
pip 19.1 from /usr/lib/python2.7/site-packages/pip (python 2.7)
[dmwm@388792c1986c ~]$ pylint --version
No config file found, using default configuration
pylint 1.9.4, 
```

@ericvaandering this is what we discussed today.