### PR TITLE
Revert "Install pip and pylint on the wmcore_base docker image"

### DIFF
--- a/wmcore_base/Dockerfile
+++ b/wmcore_base/Dockerfile
@@ -4,9 +4,7 @@ FROM gitlab-registry.cern.ch/cmsdocks/dmwm:cms_grid
 
 RUN echo "Updating the base system - 2017-06-16"
 
-RUN yum -y install cern-get-sso-cookie python-pip && yum clean all
-RUN pip --no-cache-dir install --upgrade pip setuptools
-RUN pip --no-cache-dir install pylint==1.9.4
+RUN yum -y install cern-get-sso-cookie && yum clean all
 
 # Add a new user (CMS stuff refuses to install as root)
 


### PR DESCRIPTION
Reverts dmwm/Docker#122

@ericvaandering Eric, this has been fixed in cmsdist: https://github.com/cms-sw/cmsdist/pull/4904

and we no longer need to install those RPMs in the docker image.