### PR TITLE
Run pylint py3 compatibility check on every PR

### DIFF
--- a/jenkins_python/templates/pylint3k.jinja
+++ b/jenkins_python/templates/pylint3k.jinja
@@ -1,0 +1,27 @@
+{% macro line_report(line, severity, code, module, message, okWarnings) -%}
+    {%- if module %}
+        {{ severity }}{{ code }}, line {{ line }} in {{ module }}: {{ message }}
+    {%- else %}
+        {{ severity }}{{ code }}, line {{ line }}: {{ message }}
+    {%- endif %}
+{%- endmacro %}
+
+
+<a name="pylint3k"/>
+<h1 id="pylint3k">Report from pylint Python 3 incompatible code, by file and severity</h1>
+<ul>
+    {% for filename, filereport in report|dictsort %}
+        <li>{{ filename }}</li>
+        <ul>
+            {% for severity in ['E', 'W', 'R', 'C', 'I'] %} {# EWRCI #}
+                {% if 'test' in filereport %}
+                    {% for event in filereport['test']['events'] %}
+                        {% if event[1] == severity %}
+                            <li>{{ line_report(event[0], event[1], event[2], event[3], event[4], okWarnings) }}</li>
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        </ul>
+    {% endfor %}
+</ul>

--- a/wmcore_base/ContainerScripts/pylint3kTest.sh
+++ b/wmcore_base/ContainerScripts/pylint3kTest.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+if [ -z "$ghprbPullId" -o -z "$ghprbTargetBranch" ]; then
+  echo "Not all necessary environment variables set: ghprbPullId, ghprbTargetBranch"
+  exit 1
+fi
+
+# Setup the environment
+source ./env_unittest.sh
+pushd wmcore_unittest/WMCore
+export PYTHONPATH=`pwd`/test/python:`pwd`/src/python:$PYTHONPATH
+
+# Figure out the one commit we are interested in and what happens to the repo if we were to merge it
+git config remote.origin.url https://github.com/dmwm/WMCore.git
+git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
+export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
+git checkout ${ghprbTargetBranch}
+git pull
+
+# Which python files changed?
+git diff --name-only  ${ghprbTargetBranch}..${COMMIT} > allChangedFiles.txt
+${HOME}/ContainerScripts/IdentifyPythonFiles.py allChangedFiles.txt > changedFiles.txt
+
+pylint --version
+echo "{}" > pylintReport.json
+
+# Get pylint report for the tip of our branch
+git checkout -f $COMMIT
+while read name; do
+  pylint --py3k -d W1618,W1619 --evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'  --rcfile standards/.pylintrc  --msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'  $name  > pylint.out || true
+ ${HOME}/ContainerScripts/AggregatePylint.py test
+done <changedFiles.txt
+
+# Save the artifacts to a directory shared by the container and the node
+cp pylintReport.json ${HOME}/artifacts/pylint3kReport.json
+popd


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10120

Initial changes to check for python3 incompatible code through `pylint --py3k`, through a new jenkins job.
It should be transparent for jenkins projects not yet running it.

Note: this has been implemented in the `DMWM-WMCore-PR-pylint3k` jenkins job. Changes have been applied to the `DMWM-WMCore-PR-test` jenkins job too.
