### PR TITLE
Development wmcorepy3 docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,18 +2,24 @@ stages:
   - build_1
   - build_2
   - build_3
-  
-build_cms_grid:
-  stage: build_1
-  tags:
-    - docker-image-build
-  script:
-    - docker build -t cms_grid .
-  variables:
-    TO: $CI_REGISTRY_IMAGE:cms_grid # where to push resulting image
-    CONTEXT_DIR: cms_grid
-    FROM: cern/cc7-base:latest
 
+# Reference: 
+# https://gitlab.cern.ch/gitlabci-examples/build_docker_image/-/blob/daeca041733e2af279df38a3b9e8123111c62871/.gitlab-ci.yml
+build_cms_grid:
+    stage: build_1
+    variables:
+      IMAGE_DESTINATION: ${CI_REGISTRY_IMAGE}:cms_grid
+      IMAGECACHE_DESTINATION: ${CI_REGISTRY_IMAGE}/cms_grid_cache
+    image: 
+        name: gitlab-registry.cern.ch/ci-tools/docker-image-builder
+        entrypoint: [""]
+    script:
+        - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+        - /kaniko/executor --context $CI_PROJECT_DIR/cms_grid --dockerfile $CI_PROJECT_DIR/cms_grid/Dockerfile --destination $IMAGE_DESTINATION --cache=true --cache-repo $IMAGECACHE_DESTINATION
+        - echo "Image pushed successfully to ${IMAGE_DESTINATION}"
+
+# Reference:
+# https://gitlab.cern.ch/ci-tools/docker-image-builder/-/blob/b756ab0a85983439cd241457ce33bc7e5f940b86/README.md
 
 build_jenkins_python:
   stage: build_1
@@ -22,9 +28,22 @@ build_jenkins_python:
   script:
     - docker build -t jenkins_python .
   variables:
-    TO: $CI_REGISTRY_IMAGE:jenkins_python # where to push resulting image
+    TO: $CI_REGISTRY_IMAGE:jenkins_python
     CONTEXT_DIR: jenkins_python
+    DOCKER_FILE: Dockerfile
     FROM: python:2
+
+build_jenkins_python3:
+  stage: build_1
+  tags:
+    - docker-image-build
+  script:
+    - docker build -t jenkins_python3 .
+  variables:
+    TO: $CI_REGISTRY_IMAGE:jenkins_python3
+    CONTEXT_DIR: jenkins_python
+    DOCKER_FILE: py3.Dockerfile
+    FROM: python:3.8.2
 
 build_wmcore_base:
   stage: build_2
@@ -33,7 +52,7 @@ build_wmcore_base:
   script:
     - docker build -t wmcore_base .
   variables:
-    TO: $CI_REGISTRY_IMAGE:wmcore_base # where to push resulting image
+    TO: $CI_REGISTRY_IMAGE:wmcore_base
     CONTEXT_DIR: wmcore_base
     FROM: $CI_REGISTRY_IMAGE:cms_grid
 
@@ -44,8 +63,21 @@ build_wmcore_tests:
   script:
     - docker build -t wmcore_tests .
   variables:
-    TO: $CI_REGISTRY_IMAGE:wmcore_tests # where to push resulting image
+    TO: $CI_REGISTRY_IMAGE:wmcore_tests
     CONTEXT_DIR: wmcore_tests
+    DOCKER_FILE: Dockerfile
+    FROM: $CI_REGISTRY_IMAGE:wmcore_base
+
+build_wmcorepy3_tests:
+  stage: build_3
+  tags:
+    - docker-image-build
+  script:
+    - docker build -t wmcorepy3_tests .
+  variables:
+    TO: $CI_REGISTRY_IMAGE:wmcorepy3_tests
+    CONTEXT_DIR: wmcore_tests
+    DOCKER_FILE: py3.Dockerfile
     FROM: $CI_REGISTRY_IMAGE:wmcore_base
 
 build_dbs_tests:
@@ -55,7 +87,7 @@ build_dbs_tests:
   script:
     - docker build -t dbs_tests .
   variables:
-    TO: $CI_REGISTRY_IMAGE:dbs_tests # where to push resulting image
+    TO: $CI_REGISTRY_IMAGE:dbs_tests
     CONTEXT_DIR: dbs_tests
     FROM: $CI_REGISTRY_IMAGE:wmcore_base
 
@@ -66,7 +98,7 @@ build_crab_tests:
   script:
     - docker build -t crab_tests .
   variables:
-    TO: $CI_REGISTRY_IMAGE:crab_tests # where to push resulting image
+    TO: $CI_REGISTRY_IMAGE:crab_tests
     CONTEXT_DIR: crab_tests
     FROM: $CI_REGISTRY_IMAGE:wmcore_base
 

--- a/jenkins_python/py3.Dockerfile
+++ b/jenkins_python/py3.Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.8.2
+
+# Add the extra python libraries we need
+
+RUN pip --no-cache-dir install Jinja2
+RUN pip --no-cache-dir install PyGithub
+RUN pip --no-cache-dir install xunitparser
+
+RUN mkdir artifacts
+
+COPY scripts scripts
+COPY templates templates
+
+# Keep this at the end to avoid caching
+RUN curl -o UnstableTests.txt https://raw.githubusercontent.com/dmwm/WMCore/master/test/etc/UnstableTests.txt
+
+ENTRYPOINT ["scripts/PullRequestReport.py"]

--- a/wmcore_base/ContainerScripts/installWMCorePy3.sh
+++ b/wmcore_base/ContainerScripts/installWMCorePy3.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# Download the script to install everything
+curl https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/deploy_unittest_py3.sh > /home/dmwm/ContainerScripts/deploy_unittest_py3.sh
+chmod +x /home/dmwm/ContainerScripts/deploy_unittest_py3.sh
+sh /home/dmwm/ContainerScripts/deploy_unittest_py3.sh
+
+echo "export PYTHONPATH=/home/dmwm/wmcore_unittest/WMCore/src/python:\$PYTHONPATH" >> ./env_unittest_py3.sh
+# Shut down services so the docker container doesn't have stale PID & socket files
+source ./env_unittest_py3.sh
+$manage stop-services
+

--- a/wmcore_base/ContainerScripts/updateGit.sh
+++ b/wmcore_base/ContainerScripts/updateGit.sh
@@ -2,10 +2,10 @@
 
 pushd /home/dmwm/wmcore_unittest/WMCore/
 git pull
-git fetch --tags  https://github.com/dmwm/WMCore.git "+refs/heads/*:refs/remotes/origin/*"
+git fetch --quiet --tags  https://github.com/dmwm/WMCore.git "+refs/heads/*:refs/remotes/origin/*"
 git config remote.origin.url https://github.com/dmwm/WMCore.git
 git config --add remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-git fetch --tags  https://github.com/dmwm/WMCore.git "+refs/pull/*:refs/remotes/origin/pr/*"
+git fetch --quiet --tags  https://github.com/dmwm/WMCore.git "+refs/pull/*:refs/remotes/origin/pr/*"
 
 
 

--- a/wmcore_tests/py3.Dockerfile
+++ b/wmcore_tests/py3.Dockerfile
@@ -1,0 +1,13 @@
+FROM gitlab-registry.cern.ch/cmsdocks/dmwm:wmcore_base
+
+RUN echo "2021-05-20" # Change to tickle new release
+RUN sh ContainerScripts/installWMCorePy3.sh
+
+RUN sh ContainerScripts/updateGit.sh
+
+COPY TestScripts /home/dmwm/TestScripts
+#VOLUME /home/dmwm/unittestdeploy/wmagent/current/install/
+
+ENTRYPOINT ["TestScripts/runSlice.sh"]
+CMD ["0", "10"]
+


### PR DESCRIPTION
We (@amaltaro and myself) provide a series of new scripts and dockerfiles to build a new docker with a python3 environment.

The changes have been validate in [gitlab - pipelines](https://gitlab.cern.ch/dmapelli/dmwm/-/pipelines) and look good to us.

There are a couple of things to notice:
- I changed the gitlab runner that build `cms_grid` with a new one provided by CERN IT that allows us to use `--cache=true` to cache previously built images if it does not detect any change in the Dockerfile. More info [here](https://gitlab.cern.ch/gitlabci-examples/build_docker_image/-/blob/daeca041733e2af279df38a3b9e8123111c62871/.gitlab-ci.yml). I changed only `cms_grid` because it was pretty time consuming and because it is unlikely to change often. I prefer not to change our build system too much at this stage.
- I reduced the logs from `wmcore_base/ContainerScripts/updateGit.sh` (adding `--quiet` to git commands) because they were simply a list of the `refs` in dmwm/WMCore. It was about 10k of log lines and was shadowing logs from the build. If someone needed it, please point it out and I revert those changes!
- I assumed that we wanted to call our new images `jenkins_python3`, `wmcorepy3_base` and `wmcorepy3_tests`. These names are not set in stone, I am happy to change them if you prefer something different!

Actions:
- [x] swapped the comments on two lines in `wmcore_base/ContainerScripts/installWMCorePy3.sh`