### PR TITLE
Support unit tests for python2 and python3; properly report it back to PRs

### DIFF
--- a/jenkins_python/templates/unitTestReport.jinja
+++ b/jenkins_python/templates/unitTestReport.jinja
@@ -1,5 +1,11 @@
-<a name="unittests"/>
-<h1 id="unittests">Unit test summary</h1>
+{% if whichPython == 'Python2' %}
+    <a name="unittestspy2"/>
+    <h1 id="unittestspy2">Python2 unit test summary</h1>
+{% else %}
+    <a name="unittestspy3"/>
+    <h1 id="unittestspy3">Python3 unit test summary</h1>
+{% endif %}
+
 <ul>
     {% if newFailures %}
         <li>{{ newFailures|length }} tests newly failing</li>
@@ -22,8 +28,6 @@
 </ul>
 
 {% if newFailures or added or deleted or unstableChanges or okChanges %}
-    <h1>Unit test details</h1>
-
     {% if newFailures %}
         <h2>New failures of unit tests (must be resolved)</h2>
         <ul>
@@ -32,6 +36,7 @@
             {% endfor %}
         </ul>
     {% endif %}
+
     {% if added %}
         <h2>Unit tests added</h2>
         <ul>
@@ -53,6 +58,7 @@
             {% endfor %}
         </ul>
     {% endif %}
+
     {% if unstableChanges %}
         <h2>Unstable unit tests changed (should be checked)</h2>
         <ul>
@@ -61,6 +67,7 @@
             {% endfor %}
         </ul>
     {% endif %}
+
     {% if okChanges %}
         <h2>Changed unit tests</h2>
         <ul>


### PR DESCRIPTION
Changes in this PR are:
* make pylint py3k report less verbose
* added the ability to deal with both py2 and py3 unit test reports
  * for python2, the expected jenkins output file/artifact is `nosetests-*.xml` (unchanged)
  * for python3, the expected jenkins output file/artifact is `nosetestspy3-*.xml`
* properly deal with projects that do not have unit tests (be it py2, py3, or both)
* minor changes to the Jinja template and rewording of part of the report

FYI @belforte @ddaina, all the changes provided here are meant to be compatible with other projects, but tagging you anyways in case I made a mistake :)

I'm still running a final test though. 