### PR TITLE
Add Docker image for WMCore code checks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,17 @@ build_jenkins_python3:
     DOCKER_FILE: py3.Dockerfile
     FROM: python:3.8.2
 
+build_wmcore_pylint:
+  stage: build_1
+  tags:
+    - docker-image-build
+  script:
+    - docker build -t wmcore_pylint .
+  variables:
+    TO: $CI_REGISTRY_IMAGE:wmcore_pylint
+    CONTEXT_DIR: wmcore_pylint
+    FROM: python:3.8.2-slim
+
 build_wmcore_base:
   stage: build_2
   tags:

--- a/wmcore_pylint/ContainerScripts/AggregatePylint.py
+++ b/wmcore_pylint/ContainerScripts/AggregatePylint.py
@@ -1,0 +1,95 @@
+#! /usr/bin/env python
+
+import json
+
+from optparse import OptionParser
+
+usage = "usage: %prog [options] message"
+parser = OptionParser(usage)
+(options, args) = parser.parse_args()
+if len(args) != 1:
+    parser.error("You must supply a label")
+
+label = args[0]
+
+try:
+    with open('pylintReport.json', 'r') as reportFile:
+        report = json.load(reportFile)
+except IOError:
+    report = {}
+
+warnings = 0
+errors = 0
+comments = 0
+refactors = 0
+score = 0
+
+with open('pylint.out', 'r') as pylintFile:
+    for line in pylintFile:
+        if line.startswith('Your code has been rated at '):
+            scorePart = line.strip('Your code has been rated at ')
+            score = scorePart.split('/')[0]
+            try:
+                if not filename in report:
+                    report[filename] = {}
+                if not label in report[filename]:
+                    report[filename][label] = {}
+                if filename and label:
+                    report[filename][label]['score'] = score
+            except NameError:
+                print("Score of %s found, but no filename" % score)
+
+        parts = line.split(':')
+        if len(parts) != 3:
+            continue
+        try:
+            newFilename, lineNumber, rawMessage = parts
+            newFilename = newFilename.strip()
+            if not newFilename:  # Don't update filename if we didn't find one
+                continue
+            lineNumber = int(lineNumber)
+            filename = newFilename
+            rmParts = rawMessage.split(']', 1)
+            rawCode = rmParts[0].strip()
+            message = rmParts[1].strip()
+            severity = rawCode[1:2]
+            code = rawCode[2:6]
+            shortMsg = rawCode[7:]
+            msgParts = shortMsg.split(',')
+            objectName = msgParts[1].strip()
+
+            if severity == 'R':
+                refactors += 1
+            elif severity == 'W':
+                warnings += 1
+            elif severity == 'E':
+                errors += 1
+            elif severity == 'C':
+                comments += 1
+
+            if not filename in report:
+                report[filename] = {}
+
+            if not label in report[filename]:
+                report[filename][label] = {}
+            if not 'events' in report[filename][label]:
+                report[filename][label]['events'] = []
+            report[filename][label]['events'].append((lineNumber, severity, code, objectName, message))
+
+            report[filename][label]['refactors'] = refactors
+            report[filename][label]['warnings'] = warnings
+            report[filename][label]['errors'] = errors
+            report[filename][label]['comments'] = comments
+
+        except ValueError:
+            continue
+
+with open('pylintReport.json', 'w') as reportFile:
+    json.dump(report, reportFile, indent=2)
+    reportFile.write('\n')
+
+
+
+
+
+

--- a/wmcore_pylint/ContainerScripts/IdentifyPythonFiles.py
+++ b/wmcore_pylint/ContainerScripts/IdentifyPythonFiles.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python
+
+import os
+from optparse import OptionParser
+
+usage = "usage: %prog [options] list_of_files.txt"
+parser = OptionParser(usage)
+(options, args) = parser.parse_args()
+if len(args) != 1:
+    parser.error("You must supply a file with a list of files to check")
+
+list_of_files = args[0]
+
+with open(list_of_files, 'r') as changedFiles:
+    for fileName in changedFiles:
+        fileName = fileName.strip()
+        if not fileName:
+            continue
+        if fileName.endswith('.py'):
+            print(fileName)
+            continue
+        try:
+            with open(fileName, 'r') as pyFile:
+                pyLines = pyFile.readlines()
+                if 'python' in pyLines[0]:
+                    print(fileName)
+                    continue
+        except IOError:
+            pass

--- a/wmcore_pylint/ContainerScripts/pylintTest.sh
+++ b/wmcore_pylint/ContainerScripts/pylintTest.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+if [ -z "$ghprbPullId" -o -z "$ghprbTargetBranch" ]; then
+  echo "Not all necessary environment variables set: ghprbPullId, ghprbTargetBranch"
+  exit 1
+fi
+
+echo "Executing Pylint for PR ID $ghprbPullId and target branch $ghprbTargetBranch"
+
+JSON_FILENAME=pylintpy3Report.json
+PYCODESTYLE_FILENAME=pep8py3.txt
+
+pushd /home/dmwm/WMCore
+export PYTHONPATH=`pwd`/test/python:`pwd`/src/python:$PYTHONPATH
+
+# Figure out the one commit we are interested in and what happens to the repo if we were to merge it
+git config remote.origin.url https://github.com/dmwm/WMCore.git
+git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
+export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
+git checkout ${ghprbTargetBranch}
+git pull
+
+# Which python files changed?
+git diff --name-only  ${ghprbTargetBranch}..${COMMIT} > allChangedFiles.txt
+${HOME}/ContainerScripts/IdentifyPythonFiles.py allChangedFiles.txt > changedFiles.txt
+
+echo "Printing Pylint version"
+pylint --version
+
+# Get pylint report for master
+git checkout -f $ghprbTargetBranch
+echo "{}" > pylintReport.json
+echo "*** Running Pylint on the changed files against the $ghprbTargetBranch"
+while read name; do
+  pylint --evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'  --rcfile standards/.pylintrc --msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'  $name > pylint.out || true
+ ${HOME}/ContainerScripts/AggregatePylint.py base
+done <changedFiles.txt
+
+# Get pylint report for the tip of our branch
+git checkout -f $COMMIT
+echo "*** Running Pylint on the changed files against the feature branch"
+while read name; do
+  pylint --evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'  --rcfile standards/.pylintrc  --msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'  $name  > pylint.out || true
+ ${HOME}/ContainerScripts/AggregatePylint.py test
+done <changedFiles.txt
+
+# Save the artifacts to a directory shared by the container and the node
+cp pylintReport.json ${HOME}/artifacts/$JSON_FILENAME
+
+# Do pycodestyle  analysis on tip of branch
+touch NOTHING # If changedFiles.txt is empty, this will keep it from parsing the whole directory tree
+pycodestyle NOTHING `< changedFiles.txt` > ${PYCODESTYLE_FILENAME}
+cp ${PYCODESTYLE_FILENAME} ${HOME}/artifacts/
+
+popd

--- a/wmcore_pylint/Dockerfile
+++ b/wmcore_pylint/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.8.2-slim
+
+COPY requirements.txt requirements.txt
+
+RUN apt update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install -r requirements.txt
+
+RUN useradd -ms /bin/bash dmwm
+
+USER dmwm
+ENV HOME /home/dmwm
+WORKDIR /home/dmwm
+
+RUN git clone https://github.com/dmwm/WMCore.git
+
+RUN mkdir artifacts ContainerScripts
+COPY ContainerScripts ContainerScripts
+
+ENTRYPOINT ["ContainerScripts/pylintTest.sh"]
+

--- a/wmcore_pylint/requirements.txt
+++ b/wmcore_pylint/requirements.txt
@@ -1,0 +1,2 @@
+pycodestyle==2.8.0
+pylint==2.13.5


### PR DESCRIPTION
Adds a minimal image for doing pylint and pycodestyle checks on WMCore PRs.

It will be some work to rename the `pylintpy3Report.json` and `pep8py3.txt` due to interactions with [PullRequestReport.py](https://github.com/dmwm/Docker/blob/a9e068f1cbee0704b5b14b90faceef34c5ed9271/jenkins_python/scripts/PullRequestReport.py) for other Jenkins tests for CRAB, etc. so I left them as is for now.

Using this image in the Jenkins [WMCore PR test ](https://cmssdt.cern.ch/dmwm-jenkins/job/DMWM-WMCore-PR-pylintpy3/) should fix the missing pep8/pycodestyle tests from https://github.com/dmwm/WMCore/issues/10559