### PR TITLE
crab - static analysis with pylint and pycodestyle

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,17 @@ build_wmcore_pylint:
     CONTEXT_DIR: wmcore_pylint
     FROM: python:3.8.2-slim
 
+build_crab_staticanalysis:
+  stage: build_1
+  tags:
+    - docker-image-build
+  script:
+    - docker build -t crab_staticanalysis .
+  variables:
+    TO: $CI_REGISTRY_IMAGE:crab_staticanalysis
+    CONTEXT_DIR: crab_staticanalysis
+    FROM: python:3.8.2-slim
+
 build_wmcore_base:
   stage: build_2
   tags:

--- a/crab_staticanalysis/Dockerfile
+++ b/crab_staticanalysis/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.8.2-slim
+
+RUN apt update && \
+    apt-get install -y --no-install-recommends \
+    git curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add a new user (CMS stuff refuses to install as root)
+RUN useradd -ms /bin/bash dmwm
+USER dmwm
+ENV HOME /home/dmwm
+WORKDIR /home/dmwm
+
+RUN mkdir /home/dmwm/build /home/dmwm/crab/ /home/dmwm/artifacts
+COPY dockerbuild /home/dmwm/build
+COPY crab /home/dmwm/crab
+RUN bash /home/dmwm/build/install.sh
+
+CMD [ "/bin/bash", "/home/dmwm/crab/crabPylint.sh" ]

--- a/crab_staticanalysis/README.md
+++ b/crab_staticanalysis/README.md
@@ -1,0 +1,12 @@
+### how to run static code analysis on CRAB
+
+Manually
+
+```bash
+laptop$ bash build_run.sh
+laptop$ rm -rf ~/temp/artifacts-*
+```
+
+This docker image is used in the follwing jenkins jobs:
+
+- https://cmssdt.cern.ch/dmwm-jenkins/view/CRAB/job/DMWM-CRABServer-PR-pylintpy3

--- a/crab_staticanalysis/build_run.sh
+++ b/crab_staticanalysis/build_run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# when building the image manually, push it to registry.cern.ch
+IMAGETAG=registry.cern.ch/cmscrab/crabstaticanalysis:latest
+# gitlab will automatically build this image and keep it in its registry.
+# IMAGETAG=gitlab-registry.cern.ch/cmsdocks/dmwm:crab_staticanalysis
+
+docker build --no-cache -t $IMAGETAG .
+
+# docker run -it $IMAGETAG 
+
+# test CRABServer
+mkdir -p ~/temp/artifacts-0 ~/temp/artifacts-1
+docker run \
+-e ghprbPullId=7309 -e  ghprbTargetBranch=master \
+-v ~/temp/artifacts-0/:/home/dmwm/artifacts/:Z \
+-it $IMAGETAG
+
+# test CRABClient
+docker run \
+-e ghprbPullId=5168 -e  ghprbTargetBranch=master \
+-e ghprbPullLink=https://github.com/dmwm/CRABClient/ \
+-v ~/temp/artifacts-1/:/home/dmwm/artifacts/:Z \
+-it $IMAGETAG

--- a/crab_staticanalysis/crab/AggregatePylint.py
+++ b/crab_staticanalysis/crab/AggregatePylint.py
@@ -1,0 +1,95 @@
+#! /usr/bin/env python
+
+import json
+
+from optparse import OptionParser
+
+usage = "usage: %prog [options] message"
+parser = OptionParser(usage)
+(options, args) = parser.parse_args()
+if len(args) != 1:
+    parser.error("You must supply a label")
+
+label = args[0]
+
+try:
+    with open('pylintReport.json', 'r') as reportFile:
+        report = json.load(reportFile)
+except IOError:
+    report = {}
+
+warnings = 0
+errors = 0
+comments = 0
+refactors = 0
+score = 0
+
+with open('pylint.out', 'r') as pylintFile:
+    for line in pylintFile:
+        if line.startswith('Your code has been rated at '):
+            scorePart = line.strip('Your code has been rated at ')
+            score = scorePart.split('/')[0]
+            try:
+                if not filename in report:
+                    report[filename] = {}
+                if not label in report[filename]:
+                    report[filename][label] = {}
+                if filename and label:
+                    report[filename][label]['score'] = score
+            except NameError:
+                print("Score of %s found, but no filename" % score)
+
+        parts = line.split(':')
+        if len(parts) != 3:
+            continue
+        try:
+            newFilename, lineNumber, rawMessage = parts
+            newFilename = newFilename.strip()
+            if not newFilename:  # Don't update filename if we didn't find one
+                continue
+            lineNumber = int(lineNumber)
+            filename = newFilename
+            rmParts = rawMessage.split(']', 1)
+            rawCode = rmParts[0].strip()
+            message = rmParts[1].strip()
+            severity = rawCode[1:2]
+            code = rawCode[2:6]
+            shortMsg = rawCode[7:]
+            msgParts = shortMsg.split(',')
+            objectName = msgParts[1].strip()
+
+            if severity == 'R':
+                refactors += 1
+            elif severity == 'W':
+                warnings += 1
+            elif severity == 'E':
+                errors += 1
+            elif severity == 'C':
+                comments += 1
+
+            if not filename in report:
+                report[filename] = {}
+
+            if not label in report[filename]:
+                report[filename][label] = {}
+            if not 'events' in report[filename][label]:
+                report[filename][label]['events'] = []
+            report[filename][label]['events'].append((lineNumber, severity, code, objectName, message))
+
+            report[filename][label]['refactors'] = refactors
+            report[filename][label]['warnings'] = warnings
+            report[filename][label]['errors'] = errors
+            report[filename][label]['comments'] = comments
+
+        except ValueError:
+            continue
+
+with open('pylintReport.json', 'w') as reportFile:
+    json.dump(report, reportFile, indent=2)
+    reportFile.write('\n')
+
+
+
+
+
+

--- a/crab_staticanalysis/crab/IdentifyPythonFiles.py
+++ b/crab_staticanalysis/crab/IdentifyPythonFiles.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python
+
+import os
+from optparse import OptionParser
+
+usage = "usage: %prog [options] list_of_files.txt"
+parser = OptionParser(usage)
+(options, args) = parser.parse_args()
+if len(args) != 1:
+    parser.error("You must supply a file with a list of files to check")
+
+list_of_files = args[0]
+
+with open(list_of_files, 'r') as changedFiles:
+    for fileName in changedFiles:
+        fileName = fileName.strip()
+        if not fileName:
+            continue
+        if fileName.endswith('.py'):
+            print(fileName)
+            continue
+        try:
+            with open(fileName, 'r') as pyFile:
+                pyLines = pyFile.readlines()
+                if 'python' in pyLines[0]:
+                    print(fileName)
+                    continue
+        except IOError:
+            pass

--- a/crab_staticanalysis/crab/crabPylint.sh
+++ b/crab_staticanalysis/crab/crabPylint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export PYTHONPATH=/home/dmwm/crab/WMCore/src/python:$PYTHONPATH
+export PYTHONPATH=/home/dmwm/crab/DBS/src/python:$PYTHONPATH
+export PYTHONPATH=/home/dmwm/crab/CRABServer/src/python:$PYTHONPATH
+export PYTHONPATH=/home/dmwm/crab/CRABClient/src/python:$PYTHONPATH
+
+export PATH=$PATH:/home/dmwm/.local/bin
+
+# if the input variables are empty, then we are not running this script from
+# jenkins, but we are testing the pipeline on our laptop.
+# in this latter case, we set the variables to a reasonable test value
+if [[ -z $ghprbPullId ]]; then
+    export ghprbPullId=7296
+fi
+if [[ -z $ghprbTargetBranch ]]; then
+    export ghprbTargetBranch=master
+fi
+
+echo "(DEBUG) input env variables "
+echo "(DEBUG)   \- ghprbPullId: ${ghprbPullId}"
+echo "(DEBUG)   \- ghprbTargetBranch: ${ghprbTargetBranch}"
+echo "(DEBUG) end"
+
+bash $HOME/crab/pylintTest.sh

--- a/crab_staticanalysis/crab/pylintTest.sh
+++ b/crab_staticanalysis/crab/pylintTest.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+if [ -z "$ghprbPullId" -o -z "$ghprbTargetBranch" ]; then
+  echo "Not all necessary environment variables set: ghprbPullId, ghprbTargetBranch"
+  exit 1
+fi
+
+# all available env variables described at https://plugins.jenkins.io/ghprb/
+
+echo "Executing Pylint for" 
+echo "  \- repo $ghprbPullLink"
+echo "  \- PR ID $ghprbPullId"
+echo "  \- target branch $ghprbTargetBranch"
+
+JSON_FILENAME=pylintpy3Report.json
+PYCODESTYLE_FILENAME=pep8py3.txt
+CRABREPO=CRABServer
+if [[ $ghprbPullLink == *"CRABClient"* ]]; then
+  CRABREPO=CRABClient
+fi
+
+pushd /home/dmwm/crab/$CRABREPO
+export PYTHONPATH=$(pwd)/src/python:$PYTHONPATH
+
+# Figure out the one commit we are interested in and what happens to the repo if we were to merge it
+git config remote.origin.url https://github.com/dmwm/$CRABREPO.git
+git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
+export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
+git checkout ${ghprbTargetBranch}
+git pull
+
+# Which python files changed?
+git diff --name-only  ${ghprbTargetBranch}..${COMMIT} > allChangedFiles.txt
+${HOME}/crab/IdentifyPythonFiles.py allChangedFiles.txt > changedFiles.txt
+
+echo "Printing Pylint version"
+pylint --version
+
+# Get pylint report for master
+git checkout -f $ghprbTargetBranch
+echo "{}" > pylintReport.json
+echo "*** Running Pylint on the changed files against the $ghprbTargetBranch"
+while read name; do
+  pylint --evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'  --rcfile /home/dmwm/crab/.pylintrc --msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'  $name > pylint.out || true
+ ${HOME}/crab/AggregatePylint.py base
+done <changedFiles.txt
+
+# Get pylint report for the tip of our branch
+git checkout -f $COMMIT
+echo "*** Running Pylint on the changed files against the feature branch"
+while read name; do
+  pylint --evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'  --rcfile /home/dmwm/crab/.pylintrc  --msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'  $name  > pylint.out || true
+ ${HOME}/crab/AggregatePylint.py test
+done <changedFiles.txt
+
+# Save the artifacts to a directory shared by the container and the node
+cp pylintReport.json ${HOME}/artifacts/$JSON_FILENAME
+
+# Do pycodestyle  analysis on tip of branch
+touch NOTHING # If changedFiles.txt is empty, this will keep it from parsing the whole directory tree
+pycodestyle NOTHING --format=pylint `< changedFiles.txt` > ${PYCODESTYLE_FILENAME}
+cp ${PYCODESTYLE_FILENAME} ${HOME}/artifacts/
+
+popd

--- a/crab_staticanalysis/crab/pylintTest.sh
+++ b/crab_staticanalysis/crab/pylintTest.sh
@@ -58,7 +58,7 @@ cp pylintReport.json ${HOME}/artifacts/$JSON_FILENAME
 
 # Do pycodestyle  analysis on tip of branch
 touch NOTHING # If changedFiles.txt is empty, this will keep it from parsing the whole directory tree
-pycodestyle NOTHING --format=pylint `< changedFiles.txt` > ${PYCODESTYLE_FILENAME}
+pycodestyle --config="/home/dmwm/crab/setup.cfg" NOTHING `< changedFiles.txt` > ${PYCODESTYLE_FILENAME}
 cp ${PYCODESTYLE_FILENAME} ${HOME}/artifacts/
 
 popd

--- a/crab_staticanalysis/dockerbuild/install.sh
+++ b/crab_staticanalysis/dockerbuild/install.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+set -e
+set -x
+
+GIT_CHECKOUT=master
+if [[ -z $RELEASE_TAG ]]; then
+    GIT_CHECKOUT=$RELEASE_TAG
+fi
+
+python -m pip install --user -r /home/dmwm/build/requirements.txt
+
+curl -o /home/dmwm/crab/.pylintrc https://raw.githubusercontent.com/dmwm/WMCore/master/standards/.pylintrc
+
+git clone https://github.com/dmwm/WMCore /home/dmwm/crab/WMCore
+git clone https://github.com/dmwm/DBS /home/dmwm/crab/DBS
+git clone https://github.com/dmwm/CRABServer /home/dmwm/crab/CRABServer
+git clone https://github.com/dmwm/CRABClient /home/dmwm/crab/CRABClient
+
+cd /home/dmwm/crab/CRABServer
+git checkout $GIT_CHECKOUT || true
+cd -
+cd /home/dmwm/crab/CRABClient
+git checkout $GIT_CHECKOUT || true
+cd -

--- a/crab_staticanalysis/dockerbuild/install.sh
+++ b/crab_staticanalysis/dockerbuild/install.sh
@@ -11,6 +11,7 @@ fi
 python -m pip install --user -r /home/dmwm/build/requirements.txt
 
 curl -o /home/dmwm/crab/.pylintrc https://raw.githubusercontent.com/dmwm/WMCore/master/standards/.pylintrc
+curl -o /home/dmwm/crab/setup.cfg https://raw.githubusercontent.com/dmwm/WMCore/master/setup.cfg
 
 git clone https://github.com/dmwm/WMCore /home/dmwm/crab/WMCore
 git clone https://github.com/dmwm/DBS /home/dmwm/crab/DBS

--- a/crab_staticanalysis/dockerbuild/requirements.txt
+++ b/crab_staticanalysis/dockerbuild/requirements.txt
@@ -1,0 +1,3 @@
+pycodestyle==2.8.0
+pylint==2.13.5
+# pylint==2.10

--- a/jenkins_python/scripts/PullRequestReport.py
+++ b/jenkins_python/scripts/PullRequestReport.py
@@ -426,6 +426,12 @@ if pylintSummary:
     else:
         print('Testing of python code. DMWM-SUCCEED-PYLINT')
 
+if pylintSummaryPy3:
+    if failedPylintPy3:
+        print('Testing of python code. CRAB-FAIL-PYLINTPY3')
+    else:
+        print('Testing of python code. CRAB-SUCCEED-PYLINTPY3')
+
 if pylintSummary3k:
     if failedPy3k:
         print('Testing of python code. DMWM-FAIL-PYLINT3K')

--- a/jenkins_python/scripts/PullRequestReport.py
+++ b/jenkins_python/scripts/PullRequestReport.py
@@ -428,9 +428,9 @@ if pylintSummary:
 
 if pylintSummaryPy3:
     if failedPylintPy3:
-        print('Testing of python code. CRAB-FAIL-PYLINTPY3')
+        print('Testing of python code. DMWM-FAIL-PYLINTPY3')
     else:
-        print('Testing of python code. CRAB-SUCCEED-PYLINTPY3')
+        print('Testing of python code. DMWM-SUCCEED-PYLINTPY3')
 
 if pylintSummary3k:
     if failedPy3k:


### PR DESCRIPTION
#### status

ready to be merged.

tested in:

- [x] https://github.com/dmwm/CRABServer/pull/7309
- [x] https://github.com/dmwm/CRABClient/pull/5169

Progress tracked at https://github.com/dmwm/CRABServer/issues/7152

#### description

Profiting from the work by Eric for WMCore at #132 , with this PR I add a small python3 docker image to run pylint and pycodestyle on CRABServer and CRABClient PRs. 

[EDIT] Eventually, Alan would also like to have WMCore PRs fail when the pylint in python3 checks fail. 

~~Moreover, I have a proposal for @amaltaro. Currently, when a PR fails the pylint checks, WMCore does not "officially" fail the PR [1]. Without changing this behavior, we can change `jenkins_python/scripts/PullRequestReport.py` so that we (CRAB) can do what we want with the output of the pylint/pycodestyle, independently from WMCore decisions [2].~~

Just for reference, This image is used in the jenkins job https://cmssdt.cern.ch/dmwm-jenkins/view/CRAB/job/DMWM-CRABServer-PR-test/ . I use a single jenkins job for both CRABClient and CRABServer PRs.

Thanks everybody!

fyi: @belforte 

#### logs and more info

<details><summary>[1], [2] and [3]</summary>

[1] Let's consider this PR: https://github.com/dmwm/WMCore/pull/11181 . It failed the pylint-py3 tests https://github.com/dmwm/WMCore/pull/11181#issuecomment-1158864722 , the report contains

```plaintext
src/python/WMCore/WMSpec/StdSpecs/StdBase.py
    E1128, line 908 in StdBase.factoryWorkloadConstruction: Assigning result of a function call, where the function returns None 
```

but the final visual summary reports a successful pylint-py3 check:

![image](https://user-images.githubusercontent.com/16376695/175342442-83135e7b-a17b-4a29-a8af-f92f9f942ae4.png)

If I remember correctly, this was intentional not to have spurious failures in WMCore. However, I think in CRAB we should be a bit more strict since we risk not noticing syntax errors, not having unittests that can fail the PR.

[2] Together with the changes proposed in this PR to `jenkins_python/scripts/PullRequestReport.py`, 

I would change the regex at [3] from `DMWM-FAIL` to something like `(DMWM|CRAB)-FAIL` in the jenkins jobs 

- https://cmssdt.cern.ch/dmwm-jenkins/view/CRAB/job/DMWM-CRABServer-PR-test
- https://cmssdt.cern.ch/dmwm-jenkins/view/CRAB/job/DMWM-CRABClient-PR-test

[3]

![image](https://user-images.githubusercontent.com/16376695/175343405-7098cd69-c238-4b91-a80a-b14208dc3e7e.png)

</details>
