### PR TITLE
Fix checkout target branch error, add disable=W1203 for crab_staticanalysis

### DIFF
--- a/crab_staticanalysis/Dockerfile
+++ b/crab_staticanalysis/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8.2-slim
 
 RUN apt update && \
     apt-get install -y --no-install-recommends \
-    git curl \
+    git curl patch \
     && rm -rf /var/lib/apt/lists/*
 
 # Add a new user (CMS stuff refuses to install as root)

--- a/crab_staticanalysis/build_run.sh
+++ b/crab_staticanalysis/build_run.sh
@@ -7,7 +7,7 @@ IMAGETAG=registry.cern.ch/cmscrab/crabstaticanalysis:latest
 
 docker build --no-cache -t $IMAGETAG .
 
-# docker run -it $IMAGETAG 
+# docker run -it $IMAGETAG
 
 # test CRABServer
 mkdir -p ~/temp/artifacts-0 ~/temp/artifacts-1

--- a/crab_staticanalysis/crab/pylintTest.sh
+++ b/crab_staticanalysis/crab/pylintTest.sh
@@ -7,7 +7,7 @@ fi
 
 # all available env variables described at https://plugins.jenkins.io/ghprb/
 
-echo "Executing Pylint for" 
+echo "Executing Pylint for"
 echo "  \- repo $ghprbPullLink"
 echo "  \- PR ID $ghprbPullId"
 echo "  \- target branch $ghprbTargetBranch"
@@ -24,6 +24,7 @@ export PYTHONPATH=$(pwd)/src/python:$PYTHONPATH
 
 # Figure out the one commit we are interested in and what happens to the repo if we were to merge it
 git config remote.origin.url https://github.com/dmwm/$CRABREPO.git
+git fetch origin ${ghprbTargetBranch}
 git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
 export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
 git checkout ${ghprbTargetBranch}

--- a/crab_staticanalysis/dockerbuild/dot-pylintrc.diff
+++ b/crab_staticanalysis/dockerbuild/dot-pylintrc.diff
@@ -1,0 +1,14 @@
+--- .pylintrc	2024-09-05 12:29:58.482966017 +0200
++++ .pylintrc.crab	2024-09-05 12:29:53.869759592 +0200
+@@ -44,8 +44,10 @@
+ [MESSAGES CONTROL]
+ # disable F0401 - could not import module
+ # disable E1103 - Allows attachment of dbi, logger to threading.currentThread()
++# disable W1203 - f-string logging
++
++disable=F0401, E1103, W1203
+ 
+-disable=F0401, E1103
+ 
+ 
+ # checks for :

--- a/crab_staticanalysis/dockerbuild/install.sh
+++ b/crab_staticanalysis/dockerbuild/install.sh
@@ -11,6 +11,7 @@ fi
 python -m pip install --user -r /home/dmwm/build/requirements.txt
 
 curl -o /home/dmwm/crab/.pylintrc https://raw.githubusercontent.com/dmwm/WMCore/master/standards/.pylintrc
+patch /home/dmwm/crab/.pylintrc /home/dmwm/build/dot-pylintrc.diff
 curl -o /home/dmwm/crab/setup.cfg https://raw.githubusercontent.com/dmwm/WMCore/master/setup.cfg
 
 git clone https://github.com/dmwm/WMCore /home/dmwm/crab/WMCore

--- a/crab_staticanalysis/dockerbuild/requirements.txt
+++ b/crab_staticanalysis/dockerbuild/requirements.txt
@@ -1,3 +1,3 @@
 pycodestyle==2.8.0
-pylint==2.13.5
+pylint==2.17.5
 # pylint==2.10


### PR DESCRIPTION
1. Fix checkout target branch error when the branch is not master.

2. Fix https://github.com/dmwm/CRABServer/issues/7557, add `disable=W1203` ([logging-fstring-interpolation](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/logging-fstring-interpolation.html?highlight=logging-format-style)) to disable the warning when use f-string in logging. 

3. bump pylint to latest of major version 2.

Tested in https://cmssdt.cern.ch/dmwm-jenkins/job/DMWM-CRABServer-PR-pylintpy3/1021/console

cc: @aspiringmind-code @belforte 